### PR TITLE
Add sculpture endpoints

### DIFF
--- a/controllers/sculptureController.js
+++ b/controllers/sculptureController.js
@@ -1,0 +1,162 @@
+const mongodb = require('../data/database');
+const ObjectId = require('mongodb').ObjectId;
+
+const createSculpture = async (req, res) => {
+  // #swagger.tags=['Sculpture']
+  /*  #swagger.parameters['body'] = {
+            in: 'body',
+            schema: {
+                name: 'any',
+                artist: 'any',
+                price: 'any',
+                material: 'any',
+                year: 'any'
+            }
+    } */
+  const sculpture = {
+    name: req.body.name,
+    artist: req.body.artist,
+    price: req.body.price,
+    material: req.body.material,
+    year: req.body.year || null
+  };
+
+  const result = await mongodb.getDatabase().db().collection('sculpture').insertOne(sculpture);
+
+  if (result.acknowledged) {
+    res.status(201).json({
+      id: result.insertedId
+    });
+  } else {
+    res.status(500).json(result.error || 'Some error occurred while creating the sculpture');
+  }
+};
+
+const getAll = async (req, res) => {
+  // #swagger.tags=['Sculpture']
+  try {
+    const result = await mongodb.getDatabase().db().collection('sculpture').find();
+    result.toArray().then((sculpture) => {
+      res.status(200).json(sculpture);
+    });
+  } catch (error) {
+    res.status(500).json({ message: error });
+  }
+};
+
+const getById = async (req, res) => {
+  // #swagger.tags=['Sculpture']
+  try {
+    if (!ObjectId.isValid(req.params.id)) {
+      return res.status(400).send({ message: 'Must use a valid sculpture id to find a sculpture' });
+    }
+    const sculptureId = ObjectId.createFromHexString(req.params.id);
+    const result = await mongodb
+      .getDatabase()
+      .db()
+      .collection('sculpture')
+      .find({ _id: sculptureId })
+      .toArray();
+
+      if(!result[0]) {
+        return res.status(404).json('sculpture not found.');
+      }
+      
+      res.setHeader('Content-Type', 'application/json');
+      res.status(200).json(result[0]);
+  } catch (error) {
+    res.status(500).json({ message: error });
+  }
+};
+
+const getByArtist = async (req, res) => {
+  // #swagger.tags=['Sculpture']
+  try {
+    const artist = req.params.artist;
+    const result = await mongodb.getDatabase().db().collection('sculpture').find({ artist: artist });
+    result.toArray().then((sculpture) => {
+      res.status(200).json(sculpture);
+    });
+  } catch (error) {
+    res.status(500).json({ message: error });
+  }
+};
+
+const getByMaterial = async (req, res) => {
+    // #swagger.tags=['Sculpture']
+    try {
+      const material = req.params.material;
+      const result = await mongodb.getDatabase().db().collection('sculpture').find({ material: material });
+      result.toArray().then((sculpture) => {
+        res.status(200).json(sculpture);
+      });
+    } catch (error) {
+      res.status(500).json({ message: error });
+    }
+  };
+
+const updateSculpture = async (req, res) => {
+  // #swagger.tags=['Sculpture']
+  /*  #swagger.parameters['body'] = {
+            in: 'body',
+            schema: {
+                name: 'any',
+                artist: 'any',
+                price: 'any',
+                material: 'any',
+                year: 'any'
+            }
+    } */
+  if (!ObjectId.isValid(req.params.id)) {
+    return res.status(400).json({ message: 'Must use a valid sculpture id to update a sculpture' });
+  }
+  const sculptureId = ObjectId.createFromHexString(req.params.id);
+  const sculpture = {
+    name: req.body.name,
+    artist: req.body.artist,
+    price: req.body.price,
+    material: req.body.material,
+    year: req.body.year || null
+  };
+
+  const result = await mongodb
+    .getDatabase()
+    .db()
+    .collection('sculpture')
+    .replaceOne({ _id: sculptureId }, sculpture);
+
+  if (result.modifiedCount > 0) {
+    res.status(204).send();
+  } else {
+    res.status(500).json(result.error || 'Some error ocurred while updating the sculpture');
+  }
+};
+
+const deleteSculpture = async (req, res) => {
+  // #swagger.tags=['Sculpture']
+  if (!ObjectId.isValid(req.params.id)) {
+    return res.status(400).json({ message: 'Must use a valid sculpture id to delete a sculpture' });
+  }
+  const sculptureId = ObjectId.createFromHexString(req.params.id);
+  const result = await mongodb
+    .getDatabase()
+    .db()
+    .collection('sculpture')
+    .deleteOne({ _id: sculptureId });
+
+  if (result.deletedCount > 0) {
+    res.status(204).send();
+  } else {
+    res.status(500).json(result.error || 'Some error ocurred while deleting the sculpture');
+  }
+};
+
+module.exports = {
+  createSculpture,
+  getAll,
+  getById,
+  getByArtist,
+  getByMaterial,
+  updateSculpture,
+  deleteSculpture
+};

--- a/middleware/validate.js
+++ b/middleware/validate.js
@@ -28,8 +28,28 @@ const validatePainting = (req, res, next) => {
     price: 'required|numeric',
     type: 'required|string',
     year: 'integer',
-    condition: 'string',
     tags: 'array'
+  };
+  validator(req.body, validationRule, {}, (err, status) => {
+    if (!status) {
+      res.status(412).json({
+        success: false,
+        message: 'Validation failed',
+        data: err
+      });
+    } else {
+      next();
+    }
+  });
+};
+
+const validateSculpture = (req, res, next) => {
+  const validationRule = {
+    name: 'required|string',
+    artist: 'required|string',
+    price: 'required|numeric',
+    material: 'required|string',
+    year: 'integer',
   };
   validator(req.body, validationRule, {}, (err, status) => {
     if (!status) {
@@ -46,5 +66,6 @@ const validatePainting = (req, res, next) => {
 
 module.exports = {
   validateUser,
-  validatePainting
+  validatePainting,
+  validateSculpture
 };

--- a/routes/index.js
+++ b/routes/index.js
@@ -1,7 +1,7 @@
 const router = require('express').Router();
 
 router.use('/painting', require('./paintingRoute'));
-// router.use('/sculpture', require('./sculptureRoute'));
+router.use('/sculpture', require('./sculptureRoute'));
 // router.use('/store', require('./storeRoute'));
 router.use('/user', require('./userRoute'));
 

--- a/routes/sculptureRoute.js
+++ b/routes/sculptureRoute.js
@@ -1,4 +1,37 @@
 const router = require('express').Router();
 const sculptureController = require('../controllers/sculptureController');
+const auth = require('../middleware/authenticate');
+const validate = require('../middleware/validate');
+
+// Route to create sculpture entry
+router.post(
+  '/',
+  auth.isAuthenticated,
+  validate.validateSculpture,
+  sculptureController.createSculpture
+);
+
+// Route to get data of all sculptures
+router.get('/', sculptureController.getAll);
+
+// Route to get data of a sculpture by id
+router.get('/:id', sculptureController.getById);
+
+// Route to get sculptures by artist
+router.get('/artist/:artist', sculptureController.getByArtist);
+
+// Route to get sculptures by material
+router.get('/material/:material', sculptureController.getByMaterial);
+
+// Route to update sculpture entry
+router.put(
+  '/:id',
+  auth.isAuthenticated,
+  validate.validateSculpture,
+  sculptureController.updateSculpture
+);
+
+// Route to delete sculpture entry
+router.delete('/:id', auth.isAuthenticated, sculptureController.deleteSculpture);
 
 module.exports = router;

--- a/swagger-output-localhost.json
+++ b/swagger-output-localhost.json
@@ -7,11 +7,15 @@
   },
   "host": "localhost:3000",
   "basePath": "/",
-  "schemes": ["http"],
+  "schemes": [
+    "http"
+  ],
   "paths": {
     "/painting/": {
       "post": {
-        "tags": ["Painting"],
+        "tags": [
+          "Painting"
+        ],
         "description": "",
         "parameters": [
           {
@@ -40,13 +44,11 @@
                   "type": "string",
                   "example": "any"
                 },
-                "condition": {
-                  "type": "string",
-                  "example": "any"
-                },
                 "tags": {
                   "type": "array",
-                  "example": ["any"],
+                  "example": [
+                    "any"
+                  ],
                   "items": {
                     "type": "string"
                   }
@@ -71,7 +73,9 @@
         }
       },
       "get": {
-        "tags": ["Painting"],
+        "tags": [
+          "Painting"
+        ],
         "description": "",
         "responses": {
           "200": {
@@ -85,7 +89,9 @@
     },
     "/painting/{id}": {
       "get": {
-        "tags": ["Painting"],
+        "tags": [
+          "Painting"
+        ],
         "description": "",
         "parameters": [
           {
@@ -108,7 +114,9 @@
         }
       },
       "put": {
-        "tags": ["Painting"],
+        "tags": [
+          "Painting"
+        ],
         "description": "",
         "parameters": [
           {
@@ -143,13 +151,11 @@
                   "type": "string",
                   "example": "any"
                 },
-                "condition": {
-                  "type": "string",
-                  "example": "any"
-                },
                 "tags": {
                   "type": "array",
-                  "example": ["any"],
+                  "example": [
+                    "any"
+                  ],
                   "items": {
                     "type": "string"
                   }
@@ -177,7 +183,9 @@
         }
       },
       "delete": {
-        "tags": ["Painting"],
+        "tags": [
+          "Painting"
+        ],
         "description": "",
         "parameters": [
           {
@@ -205,7 +213,9 @@
     },
     "/painting/tag/{tag}": {
       "get": {
-        "tags": ["Painting"],
+        "tags": [
+          "Painting"
+        ],
         "description": "",
         "parameters": [
           {
@@ -227,7 +237,9 @@
     },
     "/painting/artist/{artist}": {
       "get": {
-        "tags": ["Painting"],
+        "tags": [
+          "Painting"
+        ],
         "description": "",
         "parameters": [
           {
@@ -247,9 +259,247 @@
         }
       }
     },
+    "/sculpture/": {
+      "post": {
+        "tags": [
+          "Sculpture"
+        ],
+        "description": "",
+        "parameters": [
+          {
+            "name": "body",
+            "in": "body",
+            "schema": {
+              "type": "object",
+              "properties": {
+                "name": {
+                  "type": "string",
+                  "example": "any"
+                },
+                "artist": {
+                  "type": "string",
+                  "example": "any"
+                },
+                "price": {
+                  "type": "string",
+                  "example": "any"
+                },
+                "material": {
+                  "type": "string",
+                  "example": "any"
+                },
+                "year": {
+                  "type": "string",
+                  "example": "any"
+                }
+              }
+            }
+          }
+        ],
+        "responses": {
+          "201": {
+            "description": "Created"
+          },
+          "401": {
+            "description": "Unauthorized"
+          },
+          "412": {
+            "description": "Precondition Failed"
+          },
+          "500": {
+            "description": "Internal Server Error"
+          }
+        }
+      },
+      "get": {
+        "tags": [
+          "Sculpture"
+        ],
+        "description": "",
+        "responses": {
+          "200": {
+            "description": "OK"
+          },
+          "500": {
+            "description": "Internal Server Error"
+          }
+        }
+      }
+    },
+    "/sculpture/{id}": {
+      "get": {
+        "tags": [
+          "Sculpture"
+        ],
+        "description": "",
+        "produces": [
+          "application/json"
+        ],
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "required": true,
+            "type": "string"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK"
+          },
+          "400": {
+            "description": "Bad Request"
+          },
+          "404": {
+            "description": "Not Found"
+          },
+          "500": {
+            "description": "Internal Server Error"
+          }
+        }
+      },
+      "put": {
+        "tags": [
+          "Sculpture"
+        ],
+        "description": "",
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "body",
+            "in": "body",
+            "schema": {
+              "type": "object",
+              "properties": {
+                "name": {
+                  "type": "string",
+                  "example": "any"
+                },
+                "artist": {
+                  "type": "string",
+                  "example": "any"
+                },
+                "price": {
+                  "type": "string",
+                  "example": "any"
+                },
+                "material": {
+                  "type": "string",
+                  "example": "any"
+                },
+                "year": {
+                  "type": "string",
+                  "example": "any"
+                }
+              }
+            }
+          }
+        ],
+        "responses": {
+          "204": {
+            "description": "No Content"
+          },
+          "400": {
+            "description": "Bad Request"
+          },
+          "401": {
+            "description": "Unauthorized"
+          },
+          "412": {
+            "description": "Precondition Failed"
+          },
+          "500": {
+            "description": "Internal Server Error"
+          }
+        }
+      },
+      "delete": {
+        "tags": [
+          "Sculpture"
+        ],
+        "description": "",
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "required": true,
+            "type": "string"
+          }
+        ],
+        "responses": {
+          "204": {
+            "description": "No Content"
+          },
+          "400": {
+            "description": "Bad Request"
+          },
+          "401": {
+            "description": "Unauthorized"
+          },
+          "500": {
+            "description": "Internal Server Error"
+          }
+        }
+      }
+    },
+    "/sculpture/artist/{artist}": {
+      "get": {
+        "tags": [
+          "Sculpture"
+        ],
+        "description": "",
+        "parameters": [
+          {
+            "name": "artist",
+            "in": "path",
+            "required": true,
+            "type": "string"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK"
+          },
+          "500": {
+            "description": "Internal Server Error"
+          }
+        }
+      }
+    },
+    "/sculpture/material/{material}": {
+      "get": {
+        "tags": [
+          "Sculpture"
+        ],
+        "description": "",
+        "parameters": [
+          {
+            "name": "material",
+            "in": "path",
+            "required": true,
+            "type": "string"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK"
+          },
+          "500": {
+            "description": "Internal Server Error"
+          }
+        }
+      }
+    },
     "/user/": {
       "post": {
-        "tags": ["User"],
+        "tags": [
+          "User"
+        ],
         "description": "",
         "parameters": [
           {
@@ -293,7 +543,9 @@
         }
       },
       "get": {
-        "tags": ["User"],
+        "tags": [
+          "User"
+        ],
         "description": "",
         "responses": {
           "200": {
@@ -307,7 +559,9 @@
     },
     "/user/{id}": {
       "get": {
-        "tags": ["User"],
+        "tags": [
+          "User"
+        ],
         "description": "",
         "parameters": [
           {
@@ -330,7 +584,9 @@
         }
       },
       "put": {
-        "tags": ["User"],
+        "tags": [
+          "User"
+        ],
         "description": "",
         "parameters": [
           {
@@ -383,7 +639,9 @@
         }
       },
       "delete": {
-        "tags": ["User"],
+        "tags": [
+          "User"
+        ],
         "description": "",
         "parameters": [
           {

--- a/swagger-output.json
+++ b/swagger-output.json
@@ -7,11 +7,15 @@
   },
   "host": "cse341-artshop.onrender.com",
   "basePath": "/",
-  "schemes": ["https"],
+  "schemes": [
+    "https"
+  ],
   "paths": {
     "/painting/": {
       "post": {
-        "tags": ["Painting"],
+        "tags": [
+          "Painting"
+        ],
         "description": "",
         "parameters": [
           {
@@ -40,13 +44,11 @@
                   "type": "string",
                   "example": "any"
                 },
-                "condition": {
-                  "type": "string",
-                  "example": "any"
-                },
                 "tags": {
                   "type": "array",
-                  "example": ["any"],
+                  "example": [
+                    "any"
+                  ],
                   "items": {
                     "type": "string"
                   }
@@ -71,7 +73,9 @@
         }
       },
       "get": {
-        "tags": ["Painting"],
+        "tags": [
+          "Painting"
+        ],
         "description": "",
         "responses": {
           "200": {
@@ -85,7 +89,9 @@
     },
     "/painting/{id}": {
       "get": {
-        "tags": ["Painting"],
+        "tags": [
+          "Painting"
+        ],
         "description": "",
         "parameters": [
           {
@@ -108,7 +114,9 @@
         }
       },
       "put": {
-        "tags": ["Painting"],
+        "tags": [
+          "Painting"
+        ],
         "description": "",
         "parameters": [
           {
@@ -143,13 +151,11 @@
                   "type": "string",
                   "example": "any"
                 },
-                "condition": {
-                  "type": "string",
-                  "example": "any"
-                },
                 "tags": {
                   "type": "array",
-                  "example": ["any"],
+                  "example": [
+                    "any"
+                  ],
                   "items": {
                     "type": "string"
                   }
@@ -177,7 +183,9 @@
         }
       },
       "delete": {
-        "tags": ["Painting"],
+        "tags": [
+          "Painting"
+        ],
         "description": "",
         "parameters": [
           {
@@ -205,7 +213,9 @@
     },
     "/painting/tag/{tag}": {
       "get": {
-        "tags": ["Painting"],
+        "tags": [
+          "Painting"
+        ],
         "description": "",
         "parameters": [
           {
@@ -227,7 +237,9 @@
     },
     "/painting/artist/{artist}": {
       "get": {
-        "tags": ["Painting"],
+        "tags": [
+          "Painting"
+        ],
         "description": "",
         "parameters": [
           {
@@ -247,9 +259,247 @@
         }
       }
     },
+    "/sculpture/": {
+      "post": {
+        "tags": [
+          "Sculpture"
+        ],
+        "description": "",
+        "parameters": [
+          {
+            "name": "body",
+            "in": "body",
+            "schema": {
+              "type": "object",
+              "properties": {
+                "name": {
+                  "type": "string",
+                  "example": "any"
+                },
+                "artist": {
+                  "type": "string",
+                  "example": "any"
+                },
+                "price": {
+                  "type": "string",
+                  "example": "any"
+                },
+                "material": {
+                  "type": "string",
+                  "example": "any"
+                },
+                "year": {
+                  "type": "string",
+                  "example": "any"
+                }
+              }
+            }
+          }
+        ],
+        "responses": {
+          "201": {
+            "description": "Created"
+          },
+          "401": {
+            "description": "Unauthorized"
+          },
+          "412": {
+            "description": "Precondition Failed"
+          },
+          "500": {
+            "description": "Internal Server Error"
+          }
+        }
+      },
+      "get": {
+        "tags": [
+          "Sculpture"
+        ],
+        "description": "",
+        "responses": {
+          "200": {
+            "description": "OK"
+          },
+          "500": {
+            "description": "Internal Server Error"
+          }
+        }
+      }
+    },
+    "/sculpture/{id}": {
+      "get": {
+        "tags": [
+          "Sculpture"
+        ],
+        "description": "",
+        "produces": [
+          "application/json"
+        ],
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "required": true,
+            "type": "string"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK"
+          },
+          "400": {
+            "description": "Bad Request"
+          },
+          "404": {
+            "description": "Not Found"
+          },
+          "500": {
+            "description": "Internal Server Error"
+          }
+        }
+      },
+      "put": {
+        "tags": [
+          "Sculpture"
+        ],
+        "description": "",
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "body",
+            "in": "body",
+            "schema": {
+              "type": "object",
+              "properties": {
+                "name": {
+                  "type": "string",
+                  "example": "any"
+                },
+                "artist": {
+                  "type": "string",
+                  "example": "any"
+                },
+                "price": {
+                  "type": "string",
+                  "example": "any"
+                },
+                "material": {
+                  "type": "string",
+                  "example": "any"
+                },
+                "year": {
+                  "type": "string",
+                  "example": "any"
+                }
+              }
+            }
+          }
+        ],
+        "responses": {
+          "204": {
+            "description": "No Content"
+          },
+          "400": {
+            "description": "Bad Request"
+          },
+          "401": {
+            "description": "Unauthorized"
+          },
+          "412": {
+            "description": "Precondition Failed"
+          },
+          "500": {
+            "description": "Internal Server Error"
+          }
+        }
+      },
+      "delete": {
+        "tags": [
+          "Sculpture"
+        ],
+        "description": "",
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "required": true,
+            "type": "string"
+          }
+        ],
+        "responses": {
+          "204": {
+            "description": "No Content"
+          },
+          "400": {
+            "description": "Bad Request"
+          },
+          "401": {
+            "description": "Unauthorized"
+          },
+          "500": {
+            "description": "Internal Server Error"
+          }
+        }
+      }
+    },
+    "/sculpture/artist/{artist}": {
+      "get": {
+        "tags": [
+          "Sculpture"
+        ],
+        "description": "",
+        "parameters": [
+          {
+            "name": "artist",
+            "in": "path",
+            "required": true,
+            "type": "string"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK"
+          },
+          "500": {
+            "description": "Internal Server Error"
+          }
+        }
+      }
+    },
+    "/sculpture/material/{material}": {
+      "get": {
+        "tags": [
+          "Sculpture"
+        ],
+        "description": "",
+        "parameters": [
+          {
+            "name": "material",
+            "in": "path",
+            "required": true,
+            "type": "string"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK"
+          },
+          "500": {
+            "description": "Internal Server Error"
+          }
+        }
+      }
+    },
     "/user/": {
       "post": {
-        "tags": ["User"],
+        "tags": [
+          "User"
+        ],
         "description": "",
         "parameters": [
           {
@@ -293,7 +543,9 @@
         }
       },
       "get": {
-        "tags": ["User"],
+        "tags": [
+          "User"
+        ],
         "description": "",
         "responses": {
           "200": {
@@ -307,7 +559,9 @@
     },
     "/user/{id}": {
       "get": {
-        "tags": ["User"],
+        "tags": [
+          "User"
+        ],
         "description": "",
         "parameters": [
           {
@@ -330,7 +584,9 @@
         }
       },
       "put": {
-        "tags": ["User"],
+        "tags": [
+          "User"
+        ],
         "description": "",
         "parameters": [
           {
@@ -383,7 +639,9 @@
         }
       },
       "delete": {
-        "tags": ["User"],
+        "tags": [
+          "User"
+        ],
         "description": "",
         "parameters": [
           {


### PR DESCRIPTION
Now the API documentation will have a "Sculpture" section that will allow to test CRUD operations for the _sculpture_ collection, along with proper authentication, validation, and error handling. 

![image](https://github.com/user-attachments/assets/a8aaf096-a7fe-41b3-9017-98e47052482d)

# Sample data

You can copy and paste this information directly into MongoDB to get started with some sample documents.

    {"_id":{"$oid":"675c0f2b5fd030c68f3ed6a8"},"name":"Modesty","artist":"Antonio Corradini","price":"999","material":"marble","year":"1752"}
    {"_id":{"$oid":"675c0ed65fd030c68f3ed6a7"},"name":"Angel of the North","artist":"Antony Gormley","price":"350","material":"steel","year":"1994"}
    {"_id":{"$oid":"675c0ea15fd030c68f3ed6a6"},"name":"David","artist":"Michelangelo","price":"2000","material":"marble","year":"1504"}

# Merging Conflict Precaution

Merging this branch with the one that adds the _store_ endpoints will cause a minor merging conflict which has to be manually resolved, specifically to keep the validation rules of both endpoints. Although it also affects the swagger file, it can be generated again later anyways.

