### PR TITLE
Add store endpoints

### DIFF
--- a/controllers/storeController.js
+++ b/controllers/storeController.js
@@ -1,0 +1,144 @@
+const mongodb = require('../data/database');
+const ObjectId = require('mongodb').ObjectId;
+
+const createStore = async (req, res) => {
+  // #swagger.tags=['Store']
+  /*  #swagger.parameters['body'] = {
+            in: 'body',
+            schema: {
+                name: 'any',
+                itemType: 'any',
+                itemId:'any',
+                date: 'any'
+            }
+    } */
+  const store = {
+    name: req.body.name,
+    itemType: req.body.itemType,
+    itemId: req.body.itemId,
+    date: req.body.date
+  };
+
+  const result = await mongodb.getDatabase().db().collection('store').insertOne(store);
+
+  if (result.acknowledged) {
+    res.status(201).json({
+      id: result.insertedId
+    });
+  } else {
+    res.status(500).json(result.error || 'Some error occurred while creating the store order');
+  }
+};
+
+const getAll = async (req, res) => {
+  // #swagger.tags=['Store']
+  try {
+    const result = await mongodb.getDatabase().db().collection('store').find();
+    result.toArray().then((store) => {
+      res.status(200).json(store);
+    });
+  } catch (error) {
+    res.status(500).json({ message: error });
+  }
+};
+
+const getById = async (req, res) => {
+  // #swagger.tags=['Store']
+  try {
+    if (!ObjectId.isValid(req.params.id)) {
+      return res.status(400).send({ message: 'Must use a valid store id to find a store order' });
+    }
+    const storeId = ObjectId.createFromHexString(req.params.id);
+    const result = await mongodb
+      .getDatabase()
+      .db()
+      .collection('store')
+      .find({ _id: storeId })
+      .toArray();
+
+      if(!result[0]) {
+        return res.status(404).json('store order not found.');
+      }
+      
+      res.setHeader('Content-Type', 'application/json');
+      res.status(200).json(result[0]);
+  } catch (error) {
+    res.status(500).json({ message: error });
+  }
+};
+
+const getByType = async (req, res) => {
+  // #swagger.tags=['Store']
+  try {
+    const type = req.params.type;
+    const result = await mongodb.getDatabase().db().collection('store').find({ itemType: type });
+    result.toArray().then((store) => {
+      res.status(200).json(store);
+    });
+  } catch (error) {
+    res.status(500).json({ message: error });
+  }
+};
+
+const updateStore = async (req, res) => {
+  // #swagger.tags=['Store']
+  /*  #swagger.parameters['body'] = {
+            in: 'body',
+            schema: {
+                name: 'any',
+                itemType: 'any',
+                itemId:'any',
+                date: 'any'
+            }
+    } */
+  if (!ObjectId.isValid(req.params.id)) {
+    return res.status(400).json({ message: 'Must use a valid store id to update a store order' });
+  }
+  const storeId = ObjectId.createFromHexString(req.params.id);
+  const store = {
+    name: req.body.name,
+    itemType: req.body.itemType,
+    itemId: req.body.itemId,
+    date: req.body.date
+  };
+
+  const result = await mongodb
+    .getDatabase()
+    .db()
+    .collection('store')
+    .replaceOne({ _id: storeId }, store);
+
+  if (result.modifiedCount > 0) {
+    res.status(204).send();
+  } else {
+    res.status(500).json(result.error || 'Some error ocurred while updating the store order');
+  }
+};
+
+const deleteStore = async (req, res) => {
+  // #swagger.tags=['Store']
+  if (!ObjectId.isValid(req.params.id)) {
+    return res.status(400).json({ message: 'Must use a valid store id to delete a store order' });
+  }
+  const storeId = ObjectId.createFromHexString(req.params.id);
+  const result = await mongodb
+    .getDatabase()
+    .db()
+    .collection('store')
+    .deleteOne({ _id: storeId });
+
+  if (result.deletedCount > 0) {
+    res.status(204).send();
+  } else {
+    res.status(500).json(result.error || 'Some error ocurred while deleting the store order');
+  }
+};
+
+module.exports = {
+  createStore,
+  getAll,
+  getById,
+  getByType,
+  updateStore,
+  deleteStore
+};

--- a/middleware/validate.js
+++ b/middleware/validate.js
@@ -44,7 +44,28 @@ const validatePainting = (req, res, next) => {
   });
 };
 
+const validateStore = (req, res, next) => {
+  const validationRule = {
+    name: 'required|string',
+    itemType: 'required|in:painting,sculpture',
+    itemId: 'required|hex|size:24',
+    date: 'required|date',
+  };
+  validator(req.body, validationRule, {}, (err, status) => {
+    if (!status) {
+      res.status(412).json({
+        success: false,
+        message: 'Validation failed',
+        data: err
+      });
+    } else {
+      next();
+    }
+  });
+};
+
 module.exports = {
   validateUser,
-  validatePainting
+  validatePainting,
+  validateStore
 };

--- a/routes/index.js
+++ b/routes/index.js
@@ -2,7 +2,7 @@ const router = require('express').Router();
 
 router.use('/painting', require('./paintingRoute'));
 // router.use('/sculpture', require('./sculptureRoute'));
-// router.use('/store', require('./storeRoute'));
+router.use('/store', require('./storeRoute'));
 router.use('/user', require('./userRoute'));
 
 module.exports = router;

--- a/routes/storeRoute.js
+++ b/routes/storeRoute.js
@@ -1,4 +1,34 @@
 const router = require('express').Router();
 const storeController = require('../controllers/storeController');
+const auth = require('../middleware/authenticate');
+const validate = require('../middleware/validate');
+
+// Route to create store entry
+router.post(
+  '/',
+  auth.isAuthenticated,
+  validate.validateStore,
+  storeController.createStore
+);
+
+// Route to get data of all store orders
+router.get('/', storeController.getAll);
+
+// Route to get data of a store order by id
+router.get('/:id', storeController.getById);
+
+// Route to get store orders by type of item
+router.get('/type/:type', storeController.getByType);
+
+// Route to update store entry
+router.put(
+  '/:id',
+  auth.isAuthenticated,
+  validate.validateStore,
+  storeController.updateStore
+);
+
+// Route to delete store entry
+router.delete('/:id', auth.isAuthenticated, storeController.deleteStore);
 
 module.exports = router;

--- a/swagger-output-localhost.json
+++ b/swagger-output-localhost.json
@@ -7,11 +7,15 @@
   },
   "host": "localhost:3000",
   "basePath": "/",
-  "schemes": ["http"],
+  "schemes": [
+    "http"
+  ],
   "paths": {
     "/painting/": {
       "post": {
-        "tags": ["Painting"],
+        "tags": [
+          "Painting"
+        ],
         "description": "",
         "parameters": [
           {
@@ -46,7 +50,9 @@
                 },
                 "tags": {
                   "type": "array",
-                  "example": ["any"],
+                  "example": [
+                    "any"
+                  ],
                   "items": {
                     "type": "string"
                   }
@@ -71,7 +77,9 @@
         }
       },
       "get": {
-        "tags": ["Painting"],
+        "tags": [
+          "Painting"
+        ],
         "description": "",
         "responses": {
           "200": {
@@ -85,7 +93,9 @@
     },
     "/painting/{id}": {
       "get": {
-        "tags": ["Painting"],
+        "tags": [
+          "Painting"
+        ],
         "description": "",
         "parameters": [
           {
@@ -108,7 +118,9 @@
         }
       },
       "put": {
-        "tags": ["Painting"],
+        "tags": [
+          "Painting"
+        ],
         "description": "",
         "parameters": [
           {
@@ -149,7 +161,9 @@
                 },
                 "tags": {
                   "type": "array",
-                  "example": ["any"],
+                  "example": [
+                    "any"
+                  ],
                   "items": {
                     "type": "string"
                   }
@@ -177,7 +191,9 @@
         }
       },
       "delete": {
-        "tags": ["Painting"],
+        "tags": [
+          "Painting"
+        ],
         "description": "",
         "parameters": [
           {
@@ -205,7 +221,9 @@
     },
     "/painting/tag/{tag}": {
       "get": {
-        "tags": ["Painting"],
+        "tags": [
+          "Painting"
+        ],
         "description": "",
         "parameters": [
           {
@@ -227,7 +245,9 @@
     },
     "/painting/artist/{artist}": {
       "get": {
-        "tags": ["Painting"],
+        "tags": [
+          "Painting"
+        ],
         "description": "",
         "parameters": [
           {
@@ -247,9 +267,215 @@
         }
       }
     },
+    "/store/": {
+      "post": {
+        "tags": [
+          "Store"
+        ],
+        "description": "",
+        "parameters": [
+          {
+            "name": "body",
+            "in": "body",
+            "schema": {
+              "type": "object",
+              "properties": {
+                "name": {
+                  "type": "string",
+                  "example": "any"
+                },
+                "itemType": {
+                  "type": "string",
+                  "example": "any"
+                },
+                "itemId": {
+                  "type": "string",
+                  "example": "any"
+                },
+                "date": {
+                  "type": "string",
+                  "example": "any"
+                }
+              }
+            }
+          }
+        ],
+        "responses": {
+          "201": {
+            "description": "Created"
+          },
+          "401": {
+            "description": "Unauthorized"
+          },
+          "412": {
+            "description": "Precondition Failed"
+          },
+          "500": {
+            "description": "Internal Server Error"
+          }
+        }
+      },
+      "get": {
+        "tags": [
+          "Store"
+        ],
+        "description": "",
+        "responses": {
+          "200": {
+            "description": "OK"
+          },
+          "500": {
+            "description": "Internal Server Error"
+          }
+        }
+      }
+    },
+    "/store/{id}": {
+      "get": {
+        "tags": [
+          "Store"
+        ],
+        "description": "",
+        "produces": [
+          "application/json"
+        ],
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "required": true,
+            "type": "string"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK"
+          },
+          "400": {
+            "description": "Bad Request"
+          },
+          "404": {
+            "description": "Not Found"
+          },
+          "500": {
+            "description": "Internal Server Error"
+          }
+        }
+      },
+      "put": {
+        "tags": [
+          "Store"
+        ],
+        "description": "",
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "body",
+            "in": "body",
+            "schema": {
+              "type": "object",
+              "properties": {
+                "name": {
+                  "type": "string",
+                  "example": "any"
+                },
+                "itemType": {
+                  "type": "string",
+                  "example": "any"
+                },
+                "itemId": {
+                  "type": "string",
+                  "example": "any"
+                },
+                "date": {
+                  "type": "string",
+                  "example": "any"
+                }
+              }
+            }
+          }
+        ],
+        "responses": {
+          "204": {
+            "description": "No Content"
+          },
+          "400": {
+            "description": "Bad Request"
+          },
+          "401": {
+            "description": "Unauthorized"
+          },
+          "412": {
+            "description": "Precondition Failed"
+          },
+          "500": {
+            "description": "Internal Server Error"
+          }
+        }
+      },
+      "delete": {
+        "tags": [
+          "Store"
+        ],
+        "description": "",
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "required": true,
+            "type": "string"
+          }
+        ],
+        "responses": {
+          "204": {
+            "description": "No Content"
+          },
+          "400": {
+            "description": "Bad Request"
+          },
+          "401": {
+            "description": "Unauthorized"
+          },
+          "500": {
+            "description": "Internal Server Error"
+          }
+        }
+      }
+    },
+    "/store/type/{type}": {
+      "get": {
+        "tags": [
+          "Store"
+        ],
+        "description": "",
+        "parameters": [
+          {
+            "name": "type",
+            "in": "path",
+            "required": true,
+            "type": "string"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK"
+          },
+          "500": {
+            "description": "Internal Server Error"
+          }
+        }
+      }
+    },
     "/user/": {
       "post": {
-        "tags": ["User"],
+        "tags": [
+          "User"
+        ],
         "description": "",
         "parameters": [
           {
@@ -293,7 +519,9 @@
         }
       },
       "get": {
-        "tags": ["User"],
+        "tags": [
+          "User"
+        ],
         "description": "",
         "responses": {
           "200": {
@@ -307,7 +535,9 @@
     },
     "/user/{id}": {
       "get": {
-        "tags": ["User"],
+        "tags": [
+          "User"
+        ],
         "description": "",
         "parameters": [
           {
@@ -330,7 +560,9 @@
         }
       },
       "put": {
-        "tags": ["User"],
+        "tags": [
+          "User"
+        ],
         "description": "",
         "parameters": [
           {
@@ -383,7 +615,9 @@
         }
       },
       "delete": {
-        "tags": ["User"],
+        "tags": [
+          "User"
+        ],
         "description": "",
         "parameters": [
           {

--- a/swagger-output.json
+++ b/swagger-output.json
@@ -7,11 +7,15 @@
   },
   "host": "cse341-artshop.onrender.com",
   "basePath": "/",
-  "schemes": ["https"],
+  "schemes": [
+    "https"
+  ],
   "paths": {
     "/painting/": {
       "post": {
-        "tags": ["Painting"],
+        "tags": [
+          "Painting"
+        ],
         "description": "",
         "parameters": [
           {
@@ -46,7 +50,9 @@
                 },
                 "tags": {
                   "type": "array",
-                  "example": ["any"],
+                  "example": [
+                    "any"
+                  ],
                   "items": {
                     "type": "string"
                   }
@@ -71,7 +77,9 @@
         }
       },
       "get": {
-        "tags": ["Painting"],
+        "tags": [
+          "Painting"
+        ],
         "description": "",
         "responses": {
           "200": {
@@ -85,7 +93,9 @@
     },
     "/painting/{id}": {
       "get": {
-        "tags": ["Painting"],
+        "tags": [
+          "Painting"
+        ],
         "description": "",
         "parameters": [
           {
@@ -108,7 +118,9 @@
         }
       },
       "put": {
-        "tags": ["Painting"],
+        "tags": [
+          "Painting"
+        ],
         "description": "",
         "parameters": [
           {
@@ -149,7 +161,9 @@
                 },
                 "tags": {
                   "type": "array",
-                  "example": ["any"],
+                  "example": [
+                    "any"
+                  ],
                   "items": {
                     "type": "string"
                   }
@@ -177,7 +191,9 @@
         }
       },
       "delete": {
-        "tags": ["Painting"],
+        "tags": [
+          "Painting"
+        ],
         "description": "",
         "parameters": [
           {
@@ -205,7 +221,9 @@
     },
     "/painting/tag/{tag}": {
       "get": {
-        "tags": ["Painting"],
+        "tags": [
+          "Painting"
+        ],
         "description": "",
         "parameters": [
           {
@@ -227,7 +245,9 @@
     },
     "/painting/artist/{artist}": {
       "get": {
-        "tags": ["Painting"],
+        "tags": [
+          "Painting"
+        ],
         "description": "",
         "parameters": [
           {
@@ -247,9 +267,215 @@
         }
       }
     },
+    "/store/": {
+      "post": {
+        "tags": [
+          "Store"
+        ],
+        "description": "",
+        "parameters": [
+          {
+            "name": "body",
+            "in": "body",
+            "schema": {
+              "type": "object",
+              "properties": {
+                "name": {
+                  "type": "string",
+                  "example": "any"
+                },
+                "itemType": {
+                  "type": "string",
+                  "example": "any"
+                },
+                "itemId": {
+                  "type": "string",
+                  "example": "any"
+                },
+                "date": {
+                  "type": "string",
+                  "example": "any"
+                }
+              }
+            }
+          }
+        ],
+        "responses": {
+          "201": {
+            "description": "Created"
+          },
+          "401": {
+            "description": "Unauthorized"
+          },
+          "412": {
+            "description": "Precondition Failed"
+          },
+          "500": {
+            "description": "Internal Server Error"
+          }
+        }
+      },
+      "get": {
+        "tags": [
+          "Store"
+        ],
+        "description": "",
+        "responses": {
+          "200": {
+            "description": "OK"
+          },
+          "500": {
+            "description": "Internal Server Error"
+          }
+        }
+      }
+    },
+    "/store/{id}": {
+      "get": {
+        "tags": [
+          "Store"
+        ],
+        "description": "",
+        "produces": [
+          "application/json"
+        ],
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "required": true,
+            "type": "string"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK"
+          },
+          "400": {
+            "description": "Bad Request"
+          },
+          "404": {
+            "description": "Not Found"
+          },
+          "500": {
+            "description": "Internal Server Error"
+          }
+        }
+      },
+      "put": {
+        "tags": [
+          "Store"
+        ],
+        "description": "",
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "body",
+            "in": "body",
+            "schema": {
+              "type": "object",
+              "properties": {
+                "name": {
+                  "type": "string",
+                  "example": "any"
+                },
+                "itemType": {
+                  "type": "string",
+                  "example": "any"
+                },
+                "itemId": {
+                  "type": "string",
+                  "example": "any"
+                },
+                "date": {
+                  "type": "string",
+                  "example": "any"
+                }
+              }
+            }
+          }
+        ],
+        "responses": {
+          "204": {
+            "description": "No Content"
+          },
+          "400": {
+            "description": "Bad Request"
+          },
+          "401": {
+            "description": "Unauthorized"
+          },
+          "412": {
+            "description": "Precondition Failed"
+          },
+          "500": {
+            "description": "Internal Server Error"
+          }
+        }
+      },
+      "delete": {
+        "tags": [
+          "Store"
+        ],
+        "description": "",
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "required": true,
+            "type": "string"
+          }
+        ],
+        "responses": {
+          "204": {
+            "description": "No Content"
+          },
+          "400": {
+            "description": "Bad Request"
+          },
+          "401": {
+            "description": "Unauthorized"
+          },
+          "500": {
+            "description": "Internal Server Error"
+          }
+        }
+      }
+    },
+    "/store/type/{type}": {
+      "get": {
+        "tags": [
+          "Store"
+        ],
+        "description": "",
+        "parameters": [
+          {
+            "name": "type",
+            "in": "path",
+            "required": true,
+            "type": "string"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK"
+          },
+          "500": {
+            "description": "Internal Server Error"
+          }
+        }
+      }
+    },
     "/user/": {
       "post": {
-        "tags": ["User"],
+        "tags": [
+          "User"
+        ],
         "description": "",
         "parameters": [
           {
@@ -293,7 +519,9 @@
         }
       },
       "get": {
-        "tags": ["User"],
+        "tags": [
+          "User"
+        ],
         "description": "",
         "responses": {
           "200": {
@@ -307,7 +535,9 @@
     },
     "/user/{id}": {
       "get": {
-        "tags": ["User"],
+        "tags": [
+          "User"
+        ],
         "description": "",
         "parameters": [
           {
@@ -330,7 +560,9 @@
         }
       },
       "put": {
-        "tags": ["User"],
+        "tags": [
+          "User"
+        ],
         "description": "",
         "parameters": [
           {
@@ -383,7 +615,9 @@
         }
       },
       "delete": {
-        "tags": ["User"],
+        "tags": [
+          "User"
+        ],
         "description": "",
         "parameters": [
           {


### PR DESCRIPTION
Now the API documentation will have a "Store" section that will allow to test CRUD operations for the _store_ collection, along with proper authentication, validation, and error handling. 

![image](https://github.com/user-attachments/assets/d664ddec-de07-424e-8f8b-457b392907f9)

# Sample data

You can copy and paste this information directly into MongoDB to get started with some sample documents.

```
{"_id":{"$oid":"675c100c5fd030c68f3ed6ab"},"name":"Mark","itemType":"sculpture","itemId":"675c0ea15fd030c68f3ed6a6","date":"2018-12-12"}
{"_id":{"$oid":"675c0fef5fd030c68f3ed6aa"},"name":"Joseph","itemType":"sculpture","itemId":"675c0f2b5fd030c68f3ed6a8","date":"2004-12-12"}
{"_id":{"$oid":"675c0fa95fd030c68f3ed6a9"},"name":"Maria","itemType":"painting","itemId":"67585bb4e1f936d10bdc5000","date":"2024-06-07"}
```

# Validation Measure - Invalid item type scenario 

To keep the database consistent, I restrained the possible item types to only the two we are utilizing: "painting" or "sculpture"

![image](https://github.com/user-attachments/assets/ce0186f2-7ce3-4243-be64-39e6deb47201)

Anything else will not be accepted by the validator.

# Merging Conflict Precaution

Merging this branch with the one that adds the _sculpture_ endpoints will cause a minor merging conflict which has to be manually resolved, specifically to keep the validation rules of both endpoints. Although it also affects the swagger file, it can be generated again later anyways.

